### PR TITLE
Automatically detect templates in a scan path #85

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+What's changed since v0.3.0:
+
+- New Features:
+  - Automatically detect templates in a scan path. [#85](https://github.com/Azure/PSDocs.Azure/issues/85)
+    - To scan templates use `Invoke-PSDocument` with `-InputPath`.
+
 ## v0.3.0
 
 What's changed since v0.2.0:

--- a/pipeline.build.ps1
+++ b/pipeline.build.ps1
@@ -155,19 +155,19 @@ task PSScriptAnalyzer NuGet, {
 
 # Synopsis: Install PSRule
 task PSRule NuGet, {
-    if ($Null -eq (Get-InstalledModule -Name PSRule -MinimumVersion 1.0.3 -ErrorAction Ignore)) {
-        Install-Module -Name PSRule -Repository PSGallery -MinimumVersion 1.0.3 -Scope CurrentUser -Force;
+    if ($Null -eq (Get-InstalledModule -Name PSRule -MinimumVersion 1.4.0 -ErrorAction Ignore)) {
+        Install-Module -Name PSRule -Repository PSGallery -MinimumVersion 1.4.0 -Scope CurrentUser -Force;
     }
-    if ($Null -eq (Get-InstalledModule -Name PSRule.Rules.MSFT.OSS -MinimumVersion '0.1.0-B2012007' -AllowPrerelease -ErrorAction Ignore)) {
-        Install-Module -Name PSRule.Rules.MSFT.OSS -Repository PSGallery -MinimumVersion '0.1.0-B2012007' -AllowPrerelease -Scope CurrentUser -Force;
+    if ($Null -eq (Get-InstalledModule -Name PSRule.Rules.MSFT.OSS -MinimumVersion 0.1.0 -AllowPrerelease -ErrorAction Ignore)) {
+        Install-Module -Name PSRule.Rules.MSFT.OSS -Repository PSGallery -MinimumVersion 0.1.0 -AllowPrerelease -Scope CurrentUser -Force;
     }
     Import-Module -Name PSRule.Rules.MSFT.OSS -Verbose:$False;
 }
 
 # Synopsis: Install PSDocs
 task PSDocs NuGet, {
-    if ($Null -eq (Get-InstalledModule -Name PSDocs -MinimumVersion 0.8.0 -ErrorAction Ignore)) {
-        Install-Module -Name PSDocs -Repository PSGallery -MinimumVersion 0.8.0 -Scope CurrentUser -Force;
+    if ($Null -eq (Get-InstalledModule -Name PSDocs -MinimumVersion '0.9.0-B2107020' -AllowPrerelease -ErrorAction Ignore)) {
+        Install-Module -Name PSDocs -Repository PSGallery -MinimumVersion '0.9.0-B2107020' -AllowPrerelease -Scope CurrentUser -Force;
     }
     Import-Module -Name PSDocs -Verbose:$False;
 }
@@ -278,7 +278,7 @@ task UpdateTemplateDocs Build, {
     # Scan for Azure template file recursively in the templates/ directory
     Get-AzDocTemplateFile -Path templates/ | ForEach-Object {
         $template = Get-Item -Path $_.TemplateFile;
-        Invoke-PSDocument -Module PSDocs.Azure -OutputPath $template.Directory.FullName -InputObject $template.FullName;
+        Invoke-PSDocument -Module PSDocs.Azure -OutputPath $template.Directory.FullName -InputPath $template.FullName;
     }
 }
 

--- a/src/PSDocs.Azure/docs/Azure.Conventions.Doc.ps1
+++ b/src/PSDocs.Azure/docs/Azure.Conventions.Doc.ps1
@@ -3,7 +3,12 @@
 
 # Synopsis: Name documents by parent path.
 Export-PSDocumentConvention 'Azure.NameByParentPath' {
-    $template = Get-Item -Path $PSDocs.TargetObject;
+    if ($PSDocs.TargetObject -is [String]) {
+        $template = Get-Item -Path $PSDocs.TargetObject;
+    }
+    else {
+        $template = Get-Item -Path $PSDocs.Source.FullName;
+    }
 
     # Get parent directory paths where <name>/v<version>/template.json
     $version = $template.Directory.Name;

--- a/src/PSDocs.Azure/docs/Azure.Selector.Doc.yaml
+++ b/src/PSDocs.Azure/docs/Azure.Selector.Doc.yaml
@@ -1,0 +1,16 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+---
+# Synopsis: Selector Azure templates based on $schema.
+apiVersion: github.com/microsoft/PSDocs/v1
+kind: Selector
+metadata:
+  name: Azure.TemplateSchema
+spec:
+  if:
+    anyOf:
+    - field: $schema
+      match: 'http(s)?\:\/\/schema\.management\.azure\.com\/schemas\/.*deploymentTemplate\.json(#)?'
+    - field: '.'
+      isString: true

--- a/templates/keyvault/v1/README.md
+++ b/templates/keyvault/v1/README.md
@@ -86,7 +86,7 @@ Determine if purge protection is enabled on this Key Vault.
 
 The network firewall defined for this vault.
 
-- Default value: `@{defaultAction=Allow; bypass=AzureServices; ipRules=System.Object[]; virtualNetworkRules=System.Object[]}`
+- Default value: `@{defaultAction=Allow; bypass=AzureServices; ipRules=System.Management.Automation.PSObject[]; virtualNetworkRules=System.Management.Automation.PSObject[]}`
 
 ### workspaceId
 

--- a/tests/PSDocs.Azure.Tests/Azure.Common.Tests.ps1
+++ b/tests/PSDocs.Azure.Tests/Azure.Common.Tests.ps1
@@ -52,13 +52,23 @@ Describe 'PSDocs' -Tag 'PSDocs', 'Common' {
             $result | Should -Not -BeNullOrEmpty;
         }
 
+        It 'With -InputPath' {
+            $invokeParams = @{
+                Module = 'PSDocs.Azure'
+                OutputPath = $outputPath
+                InputPath = 'tests/PSDocs.Azure.Tests/basic.template.json'
+            }
+            $result = Invoke-PSDocument @invokeParams;
+            $result | Should -Not -BeNullOrEmpty;
+        }
+
         It 'With relative path' {
             Push-Location -Path (Join-Path -Path $rootPath -ChildPath 'templates/storage/v1/');
             try {
                 $invokeParams = @{
                     Module = 'PSDocs.Azure'
                     OutputPath = $outputPath
-                    InputObject = './template.json'
+                    InputPath = './template.json'
                     Option = @{ 'Output.Culture' = 'en-US' }
                 }
                 $result = Invoke-PSDocument @invokeParams;

--- a/tests/PSDocs.Azure.Tests/Azure.Conventions.Tests.ps1
+++ b/tests/PSDocs.Azure.Tests/Azure.Conventions.Tests.ps1
@@ -24,7 +24,7 @@ $Null = New-Item -Path $outputPath -ItemType Directory -Force;
 
 Describe 'Conventions' -Tag 'Conventions' {
     Context 'Azure.NameByParentPath' {
-        It 'Uses naming convention' {
+        It 'With -InputObject' {
             $invokeParams = @{
                 Module = 'PSDocs.Azure'
             }
@@ -50,6 +50,31 @@ Describe 'Conventions' -Tag 'Conventions' {
                 $template = Get-Item -Path $_.TemplateFile;
                 Invoke-PSDocument @invokeParams -OutputPath $outputPath -InputObject $template.FullName -Convention 'Azure.NameByParentPath'
             }
+            $result | Should -Not -BeNullOrEmpty;
+            $result[0].Name | Should -BeLike 'template-test.md';
+            $result;
+        }
+
+        It 'With -InputPath' {
+            $invokeParams = @{
+                Module = 'PSDocs.Azure'
+            }
+
+            # Generates templates
+            $templatePath = Join-Path -Path $rootPath -ChildPath 'templates/';
+            $result = Invoke-PSDocument @invokeParams -OutputPath $outputPath -InputPath $templatePath -Convention 'Azure.NameByParentPath'
+            $result | Should -Not -BeNullOrEmpty;
+            $filteredResult = $result | Where-Object { $_.Name -like 'acr_*' };
+            $filteredResult.Name | Should -BeLike 'acr_v1.md';
+            $filteredResult = $result | Where-Object { $_.Name -like 'keyvault_*' };
+            $filteredResult.Name | Should -BeLike 'keyvault_v1.md';
+            $filteredResult = $result | Where-Object { $_.Name -like 'storage_*' };
+            $filteredResult.Name | Should -BeLike 'storage_v1.md';
+            $result;
+
+            # Generates templates without version path
+            $templatePath = Join-Path -Path $here -ChildPath 'template-test/';
+            $result = Invoke-PSDocument @invokeParams -OutputPath $outputPath -InputPath $templatePath -Convention 'Azure.NameByParentPath'
             $result | Should -Not -BeNullOrEmpty;
             $result[0].Name | Should -BeLike 'template-test.md';
             $result;

--- a/tests/PSDocs.Azure.Tests/Azure.QuickStart.Tests.ps1
+++ b/tests/PSDocs.Azure.Tests/Azure.QuickStart.Tests.ps1
@@ -36,7 +36,7 @@ Describe 'Templates' -Tag 'QuickStart' {
                 # Generates templates
                 $result = Get-AzDocTemplateFile -Path $templatePath | ForEach-Object {
                     $template = Get-Item -Path $_.TemplateFile;
-                    $actualContent = Invoke-PSDocument @invokeParams -OutputPath $outputPath -InputObject $template.FullName -PassThru;
+                    $actualContent = Invoke-PSDocument @invokeParams -OutputPath $outputPath -InputPath $template.FullName -PassThru;
                     $actualContent | Should -BeLike '*!`[Azure Public Test Date`](https://azurequickstartsservice.blob.core.windows.net/badges/template-test/PublicLastTestDate.svg)*';
                     $actualContent | Should -BeLike "`# Storage Account*";
                     $actualContent | Should -BeLike "*Create an empty Storage Account.*";

--- a/tests/PSDocs.Azure.Tests/Azure.Templates.Tests.ps1
+++ b/tests/PSDocs.Azure.Tests/Azure.Templates.Tests.ps1
@@ -35,7 +35,7 @@ Describe 'Templates' -Tag 'Template' {
                 $template = Get-Item -Path $_.TemplateFile;
                 $parentPath = $template.Directory.FullName;
                 $expectedContent = Get-Content -Path (Join-Path -Path $parentPath -ChildPath 'README.md') -Raw;
-                $actualContent = Invoke-PSDocument @invokeParams -OutputPath $outputPath -InputObject $template.FullName -PassThru;
+                $actualContent = Invoke-PSDocument @invokeParams -OutputPath $outputPath -InputPath $template.FullName -PassThru;
                 $actualContent | Should -BeExactly $expectedContent;
                 $actualContent;
             }


### PR DESCRIPTION
## PR Summary

- Automatically detect templates in a scan path. #85
  - To scan templates use `Invoke-PSDocument` with `-InputPath`.

Fixes #85 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
