### PR TITLE
Snippet improvements #84 #94 #95 #96

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## Unreleased
 
+What's changed since pre-release v0.4.0-B2107004:
+
+- General improvements:
+  - Secret string parameters now include an example Key Vault reference. [#94](https://github.com/Azure/PSDocs.Azure/issues/94)
+  - Improved output of parameter object default values. [#84](https://github.com/Azure/PSDocs.Azure/issues/84)
+    - Default values and allowed values now appear in a code block.
+  - Allow optional parameters to be skipped in snippet. [#96](https://github.com/Azure/PSDocs.Azure/issues/96)
+    - To exclude optional parameters from snippets configure `AZURE_SNIPPET_SKIP_OPTIONAL_PARAMETER`.
+    - See [about_PSDocs_Azure_Configuration] for details.
+- Bug fixes:
+  - Ignore function default values in snippets. [#95](https://github.com/Azure/PSDocs.Azure/issues/95)
+    - To include parameters using a function default value configure `AZURE_SNIPPET_SKIP_DEFAULT_VALUE_FN`.
+    - See [about_PSDocs_Azure_Configuration] for details.
+
 ## v0.4.0-B2107004 (pre-release)
 
 What's changed since v0.3.0:

--- a/README.md
+++ b/README.md
@@ -290,6 +290,8 @@ The following conceptual topics exist in the `PSDocs.Azure` module:
 
 - [Badges](docs/concepts/en-US/about_PSDocs_Azure_Badges.md)
 - [Configuration](docs/concepts/en-US/about_PSDocs_Azure_Configuration.md)
+  - [AZURE_SNIPPET_SKIP_DEFAULT_VALUE_FN](docs/concepts/en-US/about_PSDocs_Azure_Configuration.md#azure_snippet_skip_default_value_fn)
+  - [AZURE_SNIPPET_SKIP_OPTIONAL_PARAMETER](docs/concepts/en-US/about_PSDocs_Azure_Configuration.md#azure_snippet_skip_optional_parameter)
   - [AZURE_USE_PARAMETER_FILE_SNIPPET](docs/concepts/en-US/about_PSDocs_Azure_Configuration.md#azure_use_parameter_file_snippet)
   - [AZURE_USE_COMMAND_LINE_SNIPPET](docs/concepts/en-US/about_PSDocs_Azure_Configuration.md#azure_use_command_line_snippet)
 - [Conventions](docs/concepts/en-US/about_PSDocs_Azure_Conventions.md)

--- a/docs/setup/configuring-options.md
+++ b/docs/setup/configuring-options.md
@@ -1,0 +1,29 @@
+# Configuring options
+
+PSDocs for Azure comes with many configuration options.
+Additionally, the PSDocs engine includes several options that apply to all rules.
+You can visit the [about_PSDocs_Options][1] topic to read about general PSDocs options.
+
+  [1]: https://github.com/microsoft/PSDocs/blob/main/docs/concepts/PSDocs/en-US/about_PSDocs_Options.md
+
+## Setting options
+
+Configuration options are set within the `ps-docs.yaml` file.
+If you don't already have a `ps-docs.yaml` file you can create one in the root of your repository.
+
+Configuration can be combined as indented keys.
+Use comments to add context.
+Here are some examples:
+
+```yaml
+configuration:
+  # Show command line snippet
+  AZURE_USE_COMMAND_LINE_SNIPPET: true
+
+  # Hide parameter file snippet
+  AZURE_PARAMETER_FILE_EXPANSION: false
+```
+
+!!! Tip
+    YAML can be a bit particular about indenting.
+    If something is not working, double check that you have consistent spacing in your options file.

--- a/docs/setup/configuring-snippets.md
+++ b/docs/setup/configuring-snippets.md
@@ -1,28 +1,19 @@
-# PSDocs_Azure_Configuration
+# Configuring snippets
 
-## about_PSDocs_Azure_Configuration
+PSDocs for Azure supports a number of snippets that can be included in documentation.
+This feature can be enabled by using the following configuration options.
 
-## SHORT DESCRIPTION
+## Configuration
 
-Describes PSDocs configuration options specific to `PSDocs.Azure`.
+!!! Tip
+    Each of these configuration options are set within the `ps-docs.yaml` file.
+    To learn how to set configuration options see [Configuring options][1].
 
-## LONG DESCRIPTION
+  [1]: configuring-options.md
 
-PSDocs exposes configuration options that can be used to customize execution of document generation.
-This topic describes what configuration options are available.
+### Skip function default value parameters
 
-PSDocs configuration options can be specified by setting the configuration option in `ps-docs.yaml`.
-Additionally, configuration options can be configured in a baseline or set at runtime.
-For details of setting configuration options see [PSDocs options][options]
-
-The following configurations options are available for use:
-
-- [AZURE_SNIPPET_SKIP_DEFAULT_VALUE_FN](#azure_snippet_skip_default_value_fn)
-- [AZURE_SNIPPET_SKIP_OPTIONAL_PARAMETER](#azure_snippet_skip_optional_parameter)
-- [AZURE_USE_PARAMETER_FILE_SNIPPET](#azure_use_parameter_file_snippet)
-- [AZURE_USE_COMMAND_LINE_SNIPPET](#azure_use_command_line_snippet)
-
-### AZURE_SNIPPET_SKIP_DEFAULT_VALUE_FN
+:octicons-milestone-24: v0.4.0
 
 This configuration option determines if parameters with a function defaultValue are included in snippets.
 By default, a parameters with a function default value are not included in snippets.
@@ -51,7 +42,9 @@ configuration:
   AZURE_SNIPPET_SKIP_DEFAULT_VALUE_FN: false
 ```
 
-### AZURE_SNIPPET_SKIP_OPTIONAL_PARAMETER
+### Skip optional parameters
+
+:octicons-milestone-24: v0.4.0
 
 This configuration option determines optional parameters are included in snippets.
 By default, optional parameters are included in snippets.
@@ -80,7 +73,9 @@ configuration:
   AZURE_SNIPPET_SKIP_OPTIONAL_PARAMETER: true
 ```
 
-### AZURE_USE_PARAMETER_FILE_SNIPPET
+### Parameter file snippet
+
+:octicons-milestone-24: v0.2.0
 
 This configuration option determines if a parameter file snippet is added to documentation.
 By default, a snippet is generated.
@@ -90,7 +85,7 @@ Syntax:
 
 ```yaml
 configuration:
-  AZURE_USE_PARAMETER_FILE_SNIPPET: bool # Either true or false
+  AZURE_USE_PARAMETER_FILE_SNIPPET: bool
 ```
 
 Default:
@@ -98,18 +93,20 @@ Default:
 ```yaml
 # YAML: The default AZURE_USE_PARAMETER_FILE_SNIPPET configuration option
 configuration:
-  AZURE_USE_PARAMETER_FILE_SNIPPET: true
+  AZURE_USE_PARAMETER_FILE_SNIPPET: false
 ```
 
 Example:
 
 ```yaml
-# YAML: Prevent parameter file snippet from being generated
+# YAML: Set the AZURE_USE_PARAMETER_FILE_SNIPPET configuration option to enable expansion
 configuration:
-  AZURE_USE_PARAMETER_FILE_SNIPPET: false
+  AZURE_USE_PARAMETER_FILE_SNIPPET: true
 ```
 
-### AZURE_USE_COMMAND_LINE_SNIPPET
+### Command line snippet
+
+:octicons-milestone-24: v0.2.0
 
 This configuration option determines if a command line snippet is added to documentation.
 By default, this command line snippet is not generated.
@@ -137,15 +134,3 @@ Example:
 configuration:
   AZURE_USE_COMMAND_LINE_SNIPPET: true
 ```
-
-## NOTE
-
-An online version of this document is available at https://github.com/Azure/PSDocs.Azure/blob/main/docs/concepts/en-US/about_PSDocs_Azure_Configuration.md.
-
-## KEYWORDS
-
-- Configuration
-- Document
-- Snippet
-
-[options]: https://github.com/BernieWhite/PSDocs/blob/main/docs/concepts/PSDocs/en-US/about_PSDocs_Configuration.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -48,9 +48,9 @@ nav:
     - Releases:
       - Change log: https://github.com/Azure/PSDocs.Azure/blob/main/CHANGELOG.md
     - Support: support.md
-  # - Setup:
-  #   - Configuring options: setup/configuring-options.md
-  #   - Configuring rule defaults: setup/configuring-rules.md
+  - Setup:
+    - Configuring options: setup/configuring-options.md
+    - Configuring snippets: setup/configuring-snippets.md
   #   - Configuring expansion: setup/configuring-expansion.md
 
   #   - Configuration options: concepts/about_PSRule_Azure_Configuration.md

--- a/src/PSDocs.Azure/en/PSDocs-strings.psd1
+++ b/src/PSDocs.Azure/en/PSDocs-strings.psd1
@@ -5,8 +5,8 @@
     Parameters = 'Parameters'
     Snippets = 'Snippets'
     Outputs = 'Outputs'
-    DefaultValue = "- Default value: {0}"
-    AllowedValues = "- Allowed values: {0}"
+    DefaultValue = 'Default value'
+    AllowedValues = 'Allowed values'
     ParameterName = 'Parameter name'
     Description = 'Description'
     Type = 'Type'

--- a/templates/acr/v1/README.md
+++ b/templates/acr/v1/README.md
@@ -25,7 +25,11 @@ The name of the container registry.
 
 The location to deploy the container registry.
 
-- Default value: `[resourceGroup().location]`
+**Default value**
+
+```text
+[resourceGroup().location]
+```
 
 ### registrySku
 
@@ -33,9 +37,19 @@ The location to deploy the container registry.
 
 The container registry SKU.
 
-- Default value: `Basic`
+**Default value**
 
-- Allowed values: `Basic`, `Standard`, `Premium`
+```text
+Basic
+```
+
+**Allowed values**
+
+```text
+Basic
+Standard
+Premium
+```
 
 ### tags
 

--- a/templates/acr/v1/template.json
+++ b/templates/acr/v1/template.json
@@ -18,6 +18,7 @@
             "defaultValue": "[resourceGroup().location]",
             "metadata": {
                 "description": "The location to deploy the container registry.",
+                "strongType": "location",
                 "example": "eastus",
                 "ignore": true
             }

--- a/templates/keyvault/v1/README.md
+++ b/templates/keyvault/v1/README.md
@@ -32,7 +32,11 @@ The name of the Key Vault.
 
 The Azure region to deploy to.
 
-- Default value: `[resourceGroup().location]`
+**Default value**
+
+```text
+[resourceGroup().location]
+```
 
 ### accessPolicies
 
@@ -46,7 +50,11 @@ The access policies defined for this vault.
 
 Determines if Azure can deploy certificates from this Key Vault.
 
-- Default value: `False`
+**Default value**
+
+```text
+False
+```
 
 ### useTemplate
 
@@ -54,7 +62,11 @@ Determines if Azure can deploy certificates from this Key Vault.
 
 Determines if templates can reference secrets from this Key Vault.
 
-- Default value: `False`
+**Default value**
+
+```text
+False
+```
 
 ### useDiskEncryption
 
@@ -62,7 +74,11 @@ Determines if templates can reference secrets from this Key Vault.
 
 Determines if this Key Vault can be used for Azure Disk Encryption.
 
-- Default value: `False`
+**Default value**
+
+```text
+False
+```
 
 ### useSoftDelete
 
@@ -70,7 +86,11 @@ Determines if this Key Vault can be used for Azure Disk Encryption.
 
 Determine if soft delete is enabled on this Key Vault.
 
-- Default value: `True`
+**Default value**
+
+```text
+True
+```
 
 ### usePurgeProtection
 
@@ -78,7 +98,11 @@ Determine if soft delete is enabled on this Key Vault.
 
 Determine if purge protection is enabled on this Key Vault.
 
-- Default value: `True`
+**Default value**
+
+```text
+True
+```
 
 ### networkAcls
 
@@ -86,7 +110,16 @@ Determine if purge protection is enabled on this Key Vault.
 
 The network firewall defined for this vault.
 
-- Default value: `@{defaultAction=Allow; bypass=AzureServices; ipRules=System.Management.Automation.PSObject[]; virtualNetworkRules=System.Management.Automation.PSObject[]}`
+**Default value**
+
+```json
+{
+    "defaultAction": "Allow",
+    "bypass": "AzureServices",
+    "ipRules": [],
+    "virtualNetworkRules": []
+}
+```
 
 ### workspaceId
 

--- a/templates/keyvault/v1/template.json
+++ b/templates/keyvault/v1/template.json
@@ -18,6 +18,7 @@
             "defaultValue": "[resourceGroup().location]",
             "metadata": {
                 "description": "The Azure region to deploy to.",
+                "strongType": "location",
                 "example": "eastus",
                 "ignore": true
             }

--- a/templates/storage/v1/README.md
+++ b/templates/storage/v1/README.md
@@ -37,7 +37,11 @@ The name of the Storage Account.
 
 The Azure region to deploy to.
 
-- Default value: `[resourceGroup().location]`
+**Default value**
+
+```text
+[resourceGroup().location]
+```
 
 ### sku
 
@@ -45,9 +49,18 @@ The Azure region to deploy to.
 
 Create the Storage Account as LRS or GRS.
 
-- Default value: `Standard_LRS`
+**Default value**
 
-- Allowed values: `Standard_LRS`, `Standard_GRS`
+```text
+Standard_LRS
+```
+
+**Allowed values**
+
+```text
+Standard_LRS
+Standard_GRS
+```
 
 ### suffixLength
 
@@ -55,7 +68,11 @@ Create the Storage Account as LRS or GRS.
 
 Determine how many additional characters are added to the storage account name as a suffix.
 
-- Default value: `0`
+**Default value**
+
+```text
+0
+```
 
 ### containers
 
@@ -75,7 +92,11 @@ An array of lifecycle management policies for the storage account.
 
 The number of days to retain deleted blobs. When set to 0, soft delete is disabled.
 
-- Default value: `0`
+**Default value**
+
+```text
+0
+```
 
 ### containerSoftDeleteDays
 
@@ -83,7 +104,11 @@ The number of days to retain deleted blobs. When set to 0, soft delete is disabl
 
 The number of days to retain deleted containers. When set to 0, soft delete is disabled.
 
-- Default value: `0`
+**Default value**
+
+```text
+0
+```
 
 ### shares
 
@@ -97,7 +122,11 @@ An array of file shares to create on the storage account.
 
 Determines if large file shares are enabled. This can not be disabled once enabled.
 
-- Default value: `False`
+**Default value**
+
+```text
+False
+```
 
 ### shareSoftDeleteDays
 
@@ -105,7 +134,11 @@ Determines if large file shares are enabled. This can not be disabled once enabl
 
 The number of days to retain deleted shares. When set to 0, soft delete is disabled.
 
-- Default value: `0`
+**Default value**
+
+```text
+0
+```
 
 ### allowBlobPublicAccess
 
@@ -113,7 +146,11 @@ The number of days to retain deleted shares. When set to 0, soft delete is disab
 
 Determines if any containers can be configured with the anonymous access types of blob or container.
 
-- Default value: `False`
+**Default value**
+
+```text
+False
+```
 
 ### keyVaultPrincipalId
 

--- a/templates/storage/v1/template.json
+++ b/templates/storage/v1/template.json
@@ -18,8 +18,7 @@
             "defaultValue": "[resourceGroup().location]",
             "metadata": {
                 "description": "The Azure region to deploy to.",
-                "example": "eastus",
-                "ignore": true
+                "strongType": "location"
             }
         },
         "sku": {

--- a/tests/PSDocs.Azure.Tests/Azure.Common.Tests.ps1
+++ b/tests/PSDocs.Azure.Tests/Azure.Common.Tests.ps1
@@ -36,7 +36,7 @@ Describe 'PSDocs' -Tag 'PSDocs', 'Common' {
             $invokeParams = @{
                 Module = 'PSDocs.Azure'
                 OutputPath = $outputPath
-                InputObject = (Join-Path -Path $rootPath -ChildPath 'templates/storage/v1/template.json')
+                InputPath = 'templates/storage/v1/template.json'
             }
             $result = Invoke-PSDocument @invokeParams;
             $result | Should -Not -BeNullOrEmpty;
@@ -46,7 +46,7 @@ Describe 'PSDocs' -Tag 'PSDocs', 'Common' {
             $invokeParams = @{
                 Module = 'PSDocs.Azure'
                 OutputPath = $outputPath
-                InputObject = (Join-Path -Path $rootPath -ChildPath 'tests/PSDocs.Azure.Tests/basic.template.json')
+                InputPath = 'tests/PSDocs.Azure.Tests/basic.template.json'
             }
             $result = Invoke-PSDocument @invokeParams;
             $result | Should -Not -BeNullOrEmpty;

--- a/tests/PSDocs.Azure.Tests/Azure.Conventions.Tests.ps1
+++ b/tests/PSDocs.Azure.Tests/Azure.Conventions.Tests.ps1
@@ -31,10 +31,7 @@ Describe 'Conventions' -Tag 'Conventions' {
 
             # Generates templates
             $templatePath = Join-Path -Path $rootPath -ChildPath 'templates/';
-            $result = Get-AzDocTemplateFile -Path $templatePath | ForEach-Object {
-                $template = Get-Item -Path $_.TemplateFile;
-                Invoke-PSDocument @invokeParams -OutputPath $outputPath -InputObject $template.FullName -Convention 'Azure.NameByParentPath'
-            }
+            $result = Invoke-PSDocument @invokeParams -OutputPath $outputPath -InputPath $templatePath -Convention 'Azure.NameByParentPath'
             $result | Should -Not -BeNullOrEmpty;
             $filteredResult = $result | Where-Object { $_.Name -like 'acr_*' };
             $filteredResult.Name | Should -BeLike 'acr_v1.md';
@@ -46,10 +43,7 @@ Describe 'Conventions' -Tag 'Conventions' {
 
             # Generates templates without version path
             $templatePath = Join-Path -Path $here -ChildPath 'template-test/';
-            $result = Get-AzDocTemplateFile -Path $templatePath | ForEach-Object {
-                $template = Get-Item -Path $_.TemplateFile;
-                Invoke-PSDocument @invokeParams -OutputPath $outputPath -InputObject $template.FullName -Convention 'Azure.NameByParentPath'
-            }
+            $result = Invoke-PSDocument @invokeParams -OutputPath $outputPath -InputPath $templatePath -Convention 'Azure.NameByParentPath'
             $result | Should -Not -BeNullOrEmpty;
             $result[0].Name | Should -BeLike 'template-test.md';
             $result;

--- a/tests/PSDocs.Azure.Tests/Azure.Options.Tests.ps1
+++ b/tests/PSDocs.Azure.Tests/Azure.Options.Tests.ps1
@@ -1,0 +1,183 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+#
+# Unit tests for PSDocs.Azure options
+#
+
+[CmdletBinding()]
+param ()
+
+# Setup error handling
+$ErrorActionPreference = 'Stop';
+Set-StrictMode -Version latest;
+
+# Setup tests paths
+$rootPath = $PWD;
+Import-Module (Join-Path -Path $rootPath -ChildPath out/modules/PSDocs.Azure) -Force;
+
+Describe 'Options' -Tag 'Options' {
+    Context 'AZURE_USE_PARAMETER_FILE_SNIPPET' {
+        It 'With default' {
+            $invokeParams = @{
+                Module = 'PSDocs.Azure'
+            }
+
+            $templatePath = Join-Path -Path $rootPath -ChildPath 'templates/storage/v1/';
+            $result = Invoke-PSDocument @invokeParams -InputPath $templatePath -PassThru | Out-String;
+            $result | Should -Not -BeNullOrEmpty;
+            $result | Should -BeLike "*`"contentVersion`": `"1.0.0.0`"*";
+        }
+
+        It 'With true' {
+            $invokeParams = @{
+                Module = 'PSDocs.Azure'
+                Option = @{
+                    'Configuration.AZURE_USE_PARAMETER_FILE_SNIPPET' = $True
+                }
+            }
+
+            $templatePath = Join-Path -Path $rootPath -ChildPath 'templates/storage/v1/';
+            $result = Invoke-PSDocument @invokeParams -InputPath $templatePath -PassThru | Out-String;
+            $result | Should -Not -BeNullOrEmpty;
+            $result | Should -BeLike "*`"contentVersion`": `"1.0.0.0`"*";
+        }
+
+        It 'With false' {
+            $invokeParams = @{
+                Module = 'PSDocs.Azure'
+                Option = @{
+                    'Configuration.AZURE_USE_PARAMETER_FILE_SNIPPET' = $False
+                }
+            }
+
+            $templatePath = Join-Path -Path $rootPath -ChildPath 'templates/storage/v1/';
+            $result = Invoke-PSDocument @invokeParams -InputPath $templatePath -PassThru | Out-String;
+            $result | Should -Not -BeNullOrEmpty;
+            $result | Should -Not -BeLike "*`"contentVersion`": `"1.0.0.0`"*";
+        }
+    }
+
+    Context 'AZURE_USE_COMMAND_LINE_SNIPPET' {
+        It 'With default' {
+            $invokeParams = @{
+                Module = 'PSDocs.Azure'
+            }
+
+            $templatePath = Join-Path -Path $rootPath -ChildPath 'templates/storage/v1/';
+            $result = Invoke-PSDocument @invokeParams -InputPath $templatePath -PassThru | Out-String;
+            $result | Should -Not -BeNullOrEmpty;
+            $result | Should -Not -BeLike "*az group deployment create*";
+        }
+
+        It 'With true' {
+            $invokeParams = @{
+                Module = 'PSDocs.Azure'
+                Option = @{
+                    'Configuration.AZURE_USE_COMMAND_LINE_SNIPPET' = $True
+                }
+            }
+
+            $templatePath = Join-Path -Path $rootPath -ChildPath 'templates/storage/v1/';
+            $result = Invoke-PSDocument @invokeParams -InputPath $templatePath -PassThru | Out-String;
+            $result | Should -Not -BeNullOrEmpty;
+            $result | Should -BeLike "*az group deployment create*";
+        }
+
+        It 'With false' {
+            $invokeParams = @{
+                Module = 'PSDocs.Azure'
+                Option = @{
+                    'Configuration.AZURE_USE_COMMAND_LINE_SNIPPET' = $False
+                }
+            }
+
+            $templatePath = Join-Path -Path $rootPath -ChildPath 'templates/storage/v1/';
+            $result = Invoke-PSDocument @invokeParams -InputPath $templatePath -PassThru | Out-String;
+            $result | Should -Not -BeNullOrEmpty;
+            $result | Should -Not -BeLike "*az group deployment create*";
+        }
+    }
+
+    Context 'AZURE_SNIPPET_SKIP_OPTIONAL_PARAMETER' {
+        It 'With default' {
+            $invokeParams = @{
+                Module = 'PSDocs.Azure'
+            }
+
+            $templatePath = Join-Path -Path $rootPath -ChildPath 'templates/storage/v1/';
+            $result = Invoke-PSDocument @invokeParams -InputPath $templatePath -PassThru | Out-String;
+            $result | Should -Not -BeNullOrEmpty;
+            $result | Should -BeLike "*`"sku`": {*";
+        }
+
+        It 'With true' {
+            $invokeParams = @{
+                Module = 'PSDocs.Azure'
+                Option = @{
+                    'Configuration.AZURE_SNIPPET_SKIP_OPTIONAL_PARAMETER' = $True
+                }
+            }
+
+            $templatePath = Join-Path -Path $rootPath -ChildPath 'templates/storage/v1/';
+            $result = Invoke-PSDocument @invokeParams -InputPath $templatePath -PassThru | Out-String;
+            $result | Should -Not -BeNullOrEmpty;
+            $result | Should -Not -BeLike "*`"sku`": {*";
+        }
+
+        It 'With false' {
+            $invokeParams = @{
+                Module = 'PSDocs.Azure'
+                Option = @{
+                    'Configuration.AZURE_SNIPPET_SKIP_OPTIONAL_PARAMETER' = $False
+                }
+            }
+
+            $templatePath = Join-Path -Path $rootPath -ChildPath 'templates/storage/v1/';
+            $result = Invoke-PSDocument @invokeParams -InputPath $templatePath -PassThru | Out-String;
+            $result | Should -Not -BeNullOrEmpty;
+            $result | Should -BeLike "*`"sku`": {*";
+        }
+    }
+
+    Context 'AZURE_SNIPPET_SKIP_DEFAULT_VALUE_FN' {
+        It 'With default' {
+            $invokeParams = @{
+                Module = 'PSDocs.Azure'
+            }
+
+            $templatePath = Join-Path -Path $rootPath -ChildPath 'templates/storage/v1/';
+            $result = Invoke-PSDocument @invokeParams -InputPath $templatePath -PassThru | Out-String;
+            $result | Should -Not -BeNullOrEmpty;
+            $result | Should -Not -BeLike "*`"location`": {*";
+        }
+
+        It 'With true' {
+            $invokeParams = @{
+                Module = 'PSDocs.Azure'
+                Option = @{
+                    'Configuration.AZURE_SNIPPET_SKIP_DEFAULT_VALUE_FN' = $True
+                }
+            }
+
+            $templatePath = Join-Path -Path $rootPath -ChildPath 'templates/storage/v1/';
+            $result = Invoke-PSDocument @invokeParams -InputPath $templatePath -PassThru | Out-String;
+            $result | Should -Not -BeNullOrEmpty;
+            $result | Should -Not -BeLike "*`"location`": {*";
+        }
+
+        It 'With false' {
+            $invokeParams = @{
+                Module = 'PSDocs.Azure'
+                Option = @{
+                    'Configuration.AZURE_SNIPPET_SKIP_DEFAULT_VALUE_FN' = $False
+                }
+            }
+
+            $templatePath = Join-Path -Path $rootPath -ChildPath 'templates/storage/v1/';
+            $result = Invoke-PSDocument @invokeParams -InputPath $templatePath -PassThru | Out-String;
+            $result | Should -Not -BeNullOrEmpty;
+            $result | Should -BeLike "*`"location`": {*";
+        }
+    }
+}


### PR DESCRIPTION
## PR Summary

- Secret string parameters now include an example Key Vault reference. [#94](https://github.com/Azure/PSDocs.Azure/issues/94)
- Improved output of parameter object default values. [#84](https://github.com/Azure/PSDocs.Azure/issues/84)
  - Default values and allowed values now appear in a code block.
- Allow optional parameters to be skipped in snippet. [#96](https://github.com/Azure/PSDocs.Azure/issues/96)
  - To exclude optional parameters from snippets configure `AZURE_SNIPPET_SKIP_OPTIONAL_PARAMETER`.
- Ignore function default values in snippets. [#95](https://github.com/Azure/PSDocs.Azure/issues/95)
  - To include parameters using a function default value configure `AZURE_SNIPPET_SKIP_DEFAULT_VALUE_FN`.

Fixes #84 
Fixes #94 
Fixes #95 
Fixes #96

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
