### PR TITLE
Fixes #355  Add near full support for user-defined types

### DIFF
--- a/src/PSDocs.Azure/docs/Azure.Template.Doc.ps1
+++ b/src/PSDocs.Azure/docs/Azure.Template.Doc.ps1
@@ -366,7 +366,7 @@ Document 'README' -With 'Azure.TemplateSchema' {
 
                 if ($null -ne $definition.AdditionalProperties -and $definition.AdditionalProperties -ne $false) {
                     "**$($LocalizedData.AdditionalProperties)**"
-                    $(global:GetDefinitionReferenceMarkdownLink $definition.AdditionalProperties.'$ref') 
+                    If($null -eq $definition.AdditionalProperties.'$ref') {$definition.AdditionalProperties.type} Else {$(global:GetDefinitionReferenceMarkdownLink $definition.AdditionalProperties.'$ref')}
                 }
 
                 if($null -ne $definition.Discriminator) {

--- a/src/PSDocs.Azure/docs/Azure.Template.Doc.ps1
+++ b/src/PSDocs.Azure/docs/Azure.Template.Doc.ps1
@@ -254,7 +254,6 @@ function global:GetTemplateDefinition {
                 $definition.AdditionalProperties = $property.Value.additionalProperties;
             }
             if($null -ne $property.Value.PSObject.Properties['discriminator']) {
-                Write-Warning "Discriminator found"
                 $definition.Discriminator = $property.Value.discriminator;
             }
             $definition;

--- a/src/PSDocs.Azure/docs/Azure.Template.Doc.ps1
+++ b/src/PSDocs.Azure/docs/Azure.Template.Doc.ps1
@@ -218,7 +218,7 @@ function global:GetTemplateOutput {
         foreach ($property in $InputObject.outputs.PSObject.Properties) {
             $output = [PSCustomObject]@{
                 Name = $property.Name
-                Type = $property.Value.type
+                Type = If ($null -eq $property.Value.'$ref') {$property.Value.type} Else {$property.Value.'$ref'} 
                 Description = ''
             }
             if ([bool]$property.Value.PSObject.Properties['metadata'] -and [bool]$property.Value.metadata.PSObject.Properties['description']) {

--- a/src/PSDocs.Azure/docs/Azure.Template.Doc.ps1
+++ b/src/PSDocs.Azure/docs/Azure.Template.Doc.ps1
@@ -216,9 +216,16 @@ function global:GetTemplateOutput {
     )
     process {
         foreach ($property in $InputObject.outputs.PSObject.Properties) {
+            $type = $null;
+            if($null -eq $property.Value.'$ref') {
+                $type = $property.Value.type;
+            }
+            else {
+                $type = $property.Value.'$ref';
+            }
             $output = [PSCustomObject]@{
                 Name = $property.Name
-                Type = If ($null -eq $property.Value.'$ref') {$property.Value.type} Else {$property.Value.'$ref'} 
+                Type = $type
                 Description = ''
             }
             if ([bool]$property.Value.PSObject.Properties['metadata'] -and [bool]$property.Value.metadata.PSObject.Properties['description']) {

--- a/src/PSDocs.Azure/en/PSDocs-strings.psd1
+++ b/src/PSDocs.Azure/en/PSDocs-strings.psd1
@@ -12,7 +12,7 @@
     PropertyName = 'Property name'
     ParameterName = 'Parameter name'
     Description = 'Description'
-    Type = 'Type',
+    Type = 'Type'
     Definition = 'Definition'
     UnionTypes = 'Union types'
     DiscriminatorDescription = 'Property used to discriminate between types'

--- a/src/PSDocs.Azure/en/PSDocs-strings.psd1
+++ b/src/PSDocs.Azure/en/PSDocs-strings.psd1
@@ -3,13 +3,20 @@
 
 @{
     Parameters = 'Parameters'
+    Definitions = 'User-defined types definitions'
     Snippets = 'Snippets'
     Outputs = 'Outputs'
     DefaultValue = 'Default value'
     AllowedValues = 'Allowed values'
+    AdditionalProperties = 'Additional properties'
+    PropertyName = 'Property name'
     ParameterName = 'Parameter name'
     Description = 'Description'
-    Type = 'Type'
+    Type = 'Type',
+    Definition = 'Definition'
+    UnionTypes = 'Union types'
+    DiscriminatorDescription = 'Property used to discriminate between types'
+    Mapping = 'Mapping'
     Name = 'Name'
     DefaultTitle = 'Azure template'
     ParameterFile = 'Parameter file'
@@ -21,4 +28,5 @@
     MaxValue = 'Maximum value'
     MinLength = 'Minimum length'
     MaxLength = 'Maximum length'
+    Nullable = 'Nullable'
 }


### PR DESCRIPTION
## PR Summary

Adds support for user-defined types by adding the UDTs present in the ARM file inside the markdown file and providing a link to the used UDT definition for outputs returning a UDT .

The only missing information are from additional decorators such as `sealed` or support for the source file location when the type is imported.

Will fix #355

There is also a known bug where links to some imported types (ie: `[#definitions/_1.MyCustomType][#_1.mycustomtype]`) may not work on all markdown engines. In the visual studio code text editor, two extensions I tried could not navigate to the referenced type on click. However, on ADO code wiki the link works as expected.

## PR Checklist

- [x]  PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
