### PR TITLE
fix: set docs workflow inputPath for monorepo template location

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -35,6 +35,7 @@ jobs:
         uses: microsoft/ps-docs@main
         with:
           modules: PSDocs,PSDocs.Azure
+          inputPath: packages/psdocs-azure/templates
           outputPath: docs/templates/
           prerelease: true
 


### PR DESCRIPTION
The Docs workflow failed after the monorepo merge (#407) with:

```
Cannot process argument because the value of argument "name" is not valid.
```

**Root cause:** The `microsoft/ps-docs` action defaults to scanning from workspace root. After the monorepo restructure, `templates/` moved from root to `packages/psdocs-azure/templates/`, and the scanner was picking up invalid `template.json` files from subtree imports (test fixtures, PSDocs examples).

**Fix:** Set `inputPath: packages/psdocs-azure/templates` to restrict scanning to only the 3 valid ARM templates.

Fixes the failure in [Docs workflow run #40](https://github.com/Azure/PSDocs.Azure/actions/runs/24492184930).