### PR TITLE
fix: replace softprops/action-gh-release with gh CLI

### DIFF
--- a/.github/workflows/release-psdocs-azure.yml
+++ b/.github/workflows/release-psdocs-azure.yml
@@ -49,8 +49,10 @@ jobs:
           Publish-Module -Path packages/psdocs-azure/out/modules/PSDocs.Azure -NuGetApiKey $env:PSGALLERY_API_KEY
       
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@c95fe1489396fe8a9eb87c0abf8aa5b2ef267fda # v2.2.1
-        with:
-          name: PSDocs.Azure v${{ steps.version.outputs.version }}
-          body_path: packages/psdocs-azure/CHANGELOG.md
-          generate_release_notes: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "${{ github.ref_name }}" \
+            --title "PSDocs.Azure v${{ steps.version.outputs.version }}" \
+            --notes-file packages/psdocs-azure/CHANGELOG.md \
+            --generate-notes

--- a/.github/workflows/release-psdocs.yml
+++ b/.github/workflows/release-psdocs.yml
@@ -49,8 +49,10 @@ jobs:
           Publish-Module -Path packages/psdocs/out/modules/PSDocs -NuGetApiKey $env:PSGALLERY_API_KEY
       
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@c95fe1489396fe8a9eb87c0abf8aa5b2ef267fda # v2.2.1
-        with:
-          name: PSDocs v${{ steps.version.outputs.version }}
-          body_path: packages/psdocs/CHANGELOG.md
-          generate_release_notes: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "${{ github.ref_name }}" \
+            --title "PSDocs v${{ steps.version.outputs.version }}" \
+            --notes-file packages/psdocs/CHANGELOG.md \
+            --generate-notes

--- a/.github/workflows/release-vscode.yml
+++ b/.github/workflows/release-vscode.yml
@@ -72,10 +72,11 @@ jobs:
           npx @vscode/vsce publish --packagePath "${{ steps.vsix.outputs.file }}" --pat "$VSCE_PAT"
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@c95fe1489396fe8a9eb87c0abf8aa5b2ef267fda # v2.2.1
-        with:
-          name: VS Code Extension v${{ steps.version.outputs.version }}
-          body_path: packages/vscode-extension/CHANGELOG.md
-          generate_release_notes: true
-          files: |
-            ${{ steps.vsix.outputs.path }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "${{ github.ref_name }}" \
+            --title "VS Code Extension v${{ steps.version.outputs.version }}" \
+            --notes-file packages/vscode-extension/CHANGELOG.md \
+            --generate-notes \
+            "${{ steps.vsix.outputs.path }}"


### PR DESCRIPTION
Replace the third-party `softprops/action-gh-release` action with the built-in GitHub CLI (`gh release create`) in all three release workflows.

### Why

The Azure org's Actions allowlist doesn't include `softprops/action-gh-release`. Rather than adding a third-party action from an individual maintainer, this uses the `gh` CLI which is pre-installed on all GitHub runners — zero supply chain risk.

### Changes

| Workflow | Before | After |
|----------|--------|-------|
| `release-psdocs-azure.yml` | `softprops/action-gh-release` | `gh release create` |
| `release-psdocs.yml` | `softprops/action-gh-release` | `gh release create` |
| `release-vscode.yml` | `softprops/action-gh-release` + file upload | `gh release create` + VSIX as positional arg |

### Also needed (repo settings)

Add these to the Actions allowlist to unblock CI:
- `actions/setup-node@*`
- `microsoft/ps-docs@*`