### PR TITLE
fix(docs): copy aliases instead of symlinks in mike deploy

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -52,4 +52,9 @@ jobs:
           python3 -m pip install -r requirements-docs.txt
 
       - name: Deploy site
-        run: mike deploy --push --update-aliases v0 latest stable --title 'v0'
+        # --alias-type=copy: copy v0/ contents into latest/ and stable/ instead of
+        # creating symlinks. GitHub Pages legacy 'Deploy from a branch' rejects
+        # symlinks ('Failed to deploy site, please ensure the repository does not
+        # contain any hard links, symlinks ...'), and using copies keeps the URLs
+        # /latest/... and /stable/... working without that constraint.
+        run: mike deploy --push --update-aliases --alias-type=copy v0 latest stable --title 'v0'


### PR DESCRIPTION
## Summary

The `Docs` workflow succeeds, but the subsequent **GitHub Pages deployment** of the `gh-pages` branch fails:

> Failed to deploy site, please ensure the repository does not contain any hard links, symlinks and total size is less than 10GB.

See deployment [`4449135971`](https://github.com/Azure/PSDocs.Azure/deployments) (2026-04-22) and multiple older `pages/builds` entries with the same root cause.

## Root cause

`mike deploy --update-aliases v0 latest stable` defaults to `--alias-type=symlink`, creating `latest -> v0` and `stable -> v0` **symlinks** in the `gh-pages` branch. GitHub's legacy "Deploy from a branch" Pages source rejects symlinks for security.

## Fix

Add `--alias-type=copy` so mike materializes `/latest/` and `/stable/` as full directory copies of `/v0/`. URLs are unchanged from the reader's perspective; only the on-disk representation in `gh-pages` differs.

## Validation

- YAML lints clean.
- Once merged, the next push to `main` (or a `workflow_dispatch` of `Docs`) will rewrite the `gh-pages` branch with copies, and the subsequent github-pages deployment should succeed.

## Related

This is a hard prerequisite for the upcoming release cutover (PR #412 follow-ups) — the new `ProjectUri` on PSGallery must resolve to a working docs site.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
